### PR TITLE
spec: add support for py2/py3.x build

### DIFF
--- a/python-httmock.spec
+++ b/python-httmock.spec
@@ -3,7 +3,23 @@
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 
+%global dist_raw %(%{__grep} -oP "release \\K[0-9]+\\.[0-9]+" /etc/system-release | tr -d ".")
+
+%if 0%{?fedora} > 12 || 0%{?rhel} && 0%{?dist_raw} >= 75
+%bcond_without python3
+%else
+%bcond_with python3
+%endif
+
+# centos 7.2 and lower versions don't have %py2_* macros, so define it manually
+%if 0%{?rhel} && 0%{?dist_raw} <= 72
+%{!?py2_build: %global py2_build %py_build}
+%{!?py2_install: %global py2_install %py_install}
+%endif
+
 %define pkgname httmock
+%global sum A mocking library for requests
+%global descr A mocking library for `requests` for Python 2.6, 2.7 and 3.2, 3.3.
 
 %define nose_version %nil
 %if 0%{?rhel} <= 6
@@ -11,45 +27,99 @@
 %endif
 
 Name: python-%{pkgname}
-Summary: A mocking library for requests
+Summary: %{sum}
 Version: 1.2.3
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: Apache License, Version 2.0
 
 Group: Development/Testing
 URL: https://github.com/patrys/httmock
 Source0: %{pkgname}-%{version}.tar.gz
 
-Requires: python-requests >= 1.0.0
-BuildRequires: python-requests >= 1.0.0
-BuildRequires: python-nose%{nose_version}, python2-devel
 
 BuildArch: noarch
 
 %description
-A mocking library for `requests` for Python 2.6, 2.7 and 3.2, 3.3.
+%{descr}
+
+
+%package -n python2-%{pkgname}
+Summary:       %{sum}
+Requires:      python-requests >= 1.0.0
+BuildRequires: python2-devel
+BuildRequires: python-requests >= 1.0.0
+BuildRequires: python-nose%{nose_version}
+Obsoletes:     python-httmock < 1.2.3-3%{?dist}
+
+%description -n python2-%{pkgname}
+%{descr}
+
+
+%if %{with python3}
+%package -n python%{python3_pkgversion}-%{pkgname}
+Summary:       %{sum}
+Requires:      python%{python3_pkgversion}-requests >= 1.0.0
+BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-requests >= 1.0.0
+BuildRequires: python%{python3_pkgversion}-nose%{nose_version}
+
+%description -n python%{python3_pkgversion}-%{pkgname}
+%{descr}
+%endif
+
 
 %prep
 %setup -q -n %{pkgname}-%{version}
 
+
 %build
-%{__python2} setup.py build
+%py2_build
+
+%if %{with python3}
+%py3_build
+%endif
+
+
+%check
 nosetests%{nose_version} -v
 
+%if %{with python3}
+nosetests%{nose_version}-%{python3_version} -v
+%endif
+
+
 %install
-%{__python2} setup.py install -O1 --skip-build --root %{buildroot}
+[ %buildroot = "/" ] || rm -rf %buildroot
+
+%py2_install
+
+%if %{with python3}
+%py3_install
+%endif
+
 
 %clean
 rm -rf %{buildroot}
 
-%files
+
+%files -n python2-%{pkgname}
 %defattr(-,root,root,-)
-%{python2_sitelib}/httmock.py*
-%{python2_sitelib}/httmock-*.egg-info
+%{python2_sitelib}/*
 
 %doc README.md LICENSE
 
+%if %{with python3}
+%files -n python%{python3_pkgversion}-%{pkgname}
+%defattr(-,root,root,-)
+%{python3_sitelib}/*
+
+%doc README.md LICENSE
+%endif
+
 %changelog
+* Thu Jun 27 2019 Vladislav Odintsov <odivlad@gmail.com> 1.2.3-3
+- Add support for py2/py3.x build
+
 * Fri Jun 03 2016 Vladislav Odintsov <odivlad@gmail.com> 1.2.3-2
 - Fix build for el7 distros
 


### PR DESCRIPTION
This PR adds support for parallel rpm build for python2 and python3.x for EPEL-compatible systems.
Tested with el6.6, el7.2, el7.5.